### PR TITLE
Don't crash if top level views collection was modified

### DIFF
--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1707,15 +1707,21 @@ namespace Terminal.Gui {
 
 		static void ProcessKeyEvent (KeyEvent ke)
 		{
-			if (Current.ProcessHotKey (ke))
-				return;
+			foreach (var topLevel in toplevels) {
+				if (topLevel.ProcessHotKey (ke))
+					return;
+			}
 
-			if (Current.ProcessKey (ke))
-				return;
-			
-			// Process the key normally
-			if (Current.ProcessColdKey (ke))
-				return;
+			foreach (var topLevel in toplevels) {
+				if (topLevel.ProcessKey (ke))
+					return;
+			}
+
+			foreach (var topLevel in toplevels) {
+				// Process the key normally
+				if (topLevel.ProcessColdKey (ke))
+					return;
+			}
 		}
 
 		static View FindDeepestView (View start, int x, int y, out int resx, out int resy)

--- a/Terminal.Gui/Core.cs
+++ b/Terminal.Gui/Core.cs
@@ -1707,17 +1707,20 @@ namespace Terminal.Gui {
 
 		static void ProcessKeyEvent (KeyEvent ke)
 		{
-			foreach (var topLevel in toplevels) {
+			// Avoid throwing when top level views are modified
+			var copyOfTopLevelViews = toplevels.ToList();
+
+			foreach (var topLevel in copyOfTopLevelViews) {
 				if (topLevel.ProcessHotKey (ke))
 					return;
 			}
 
-			foreach (var topLevel in toplevels) {
+			foreach (var topLevel in copyOfTopLevelViews) {
 				if (topLevel.ProcessKey (ke))
 					return;
 			}
 
-			foreach (var topLevel in toplevels) {
+			foreach (var topLevel in copyOfTopLevelViews) {
 				// Process the key normally
 				if (topLevel.ProcessColdKey (ke))
 					return;

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -502,8 +502,7 @@ namespace Terminal.Gui {
 
 			result = null;
 			waitForProbe.Set();
-			tokenSource.Dispose();
-			tokenSource = new CancellationTokenSource();
+
 			try {
 				eventReady.Wait(waitTimeout, tokenSource.Token);
 			} catch (OperationCanceledException) {
@@ -512,7 +511,13 @@ namespace Terminal.Gui {
 				eventReady.Reset();
 			}
 			Debug.WriteLine("Events ready");
-			return result != null || tokenSource.IsCancellationRequested;
+
+			if (!tokenSource.IsCancellationRequested)
+				return result != null;
+
+			tokenSource.Dispose();
+			tokenSource = new CancellationTokenSource();
+			return true;
 		}
 
 		Action<KeyEvent> keyHandler;

--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -418,7 +418,6 @@ namespace Terminal.Gui {
 		ManualResetEventSlim eventReady = new ManualResetEventSlim(false);
 		ManualResetEventSlim waitForProbe = new ManualResetEventSlim(false);
 		MainLoop mainLoop;
-		Action TerminalResized;
 		WindowsConsole.CharInfo [] OutputBuffer;
 		int cols, rows;
 		WindowsConsole winConsole;
@@ -551,7 +550,7 @@ namespace Terminal.Gui {
 				rows = inputEvent.WindowBufferSizeEvent.size.Y - 1;
 				ResizeScreen ();
 				UpdateOffScreen ();
-				TerminalResized ();
+				TerminalResized?.Invoke();
 				break;
 			}
 			result = null;


### PR DESCRIPTION
Top level views collection might be modified when a dialog is being closed (Esc key).
So we need to make a copy and make sure we can safely traverse them.