### PR TITLE
Avoid throwing when the tokenSource is cancelled

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver.cs
@@ -504,7 +504,8 @@ namespace Terminal.Gui {
 			waitForProbe.Set();
 
 			try {
-				eventReady.Wait(waitTimeout, tokenSource.Token);
+				if(!tokenSource.IsCancellationRequested)
+					eventReady.Wait(waitTimeout, tokenSource.Token);
 			} catch (OperationCanceledException) {
 				return true;
 			} finally {


### PR DESCRIPTION
When invoking an action in the main loop, the token will be cancelled.
At this point when the EventsPending is running we must avoid throwing by 
waiting using an invalid token:

`eventReady.Wait(waitTimeout, tokenSource.Token)`

And make sure we reach the disposal of the token source.

Otherwise we keep throwing over and over.